### PR TITLE
Typo causing overflows and unit test failures

### DIFF
--- a/_tags
+++ b/_tags
@@ -2,4 +2,4 @@ true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, thread
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_deriving.api), package(ppx_tools.metaquot)
-<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit), package(core), use_protobuf
+<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit), use_protobuf

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
-true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string
+true: warn(@5@8@10@11@12@14@23@24@26@29@40), bin_annot, safe_string, thread
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_deriving.api), package(ppx_tools.metaquot)
-<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit), use_protobuf
+<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit), package(core), use_protobuf

--- a/opam
+++ b/opam
@@ -21,7 +21,7 @@ build-doc: [
   make "doc"
 ]
 depends: [
-  "ppx_deriving" {>= "2.0" & < "3.0"}
+  "ppx_deriving" {>= "2.0" & <= "3.0"}
   "ocamlfind"    {build}
   "ounit"        {test}
   "uint"         {test}

--- a/src/protobuf.ml
+++ b/src/protobuf.ml
@@ -7,9 +7,9 @@ type payload_kind =
 let min_int_as_int32, max_int_as_int32 = Int32.of_int min_int, Int32.of_int max_int
 let min_int_as_int64, max_int_as_int64 = Int64.of_int min_int, Int64.of_int max_int
 let min_int32_as_int64, max_int32_as_int64 =
-  Int64.of_int32 Int32.max_int, Int64.of_int32 Int32.max_int
+  Int64.of_int32 Int32.min_int, Int64.of_int32 Int32.max_int
 let min_int32_as_int, max_int32_as_int =
-  if Sys.word_size = 64 then Int32.to_int Int32.max_int, Int32.to_int Int32.max_int
+  if Sys.word_size = 64 then Int32.to_int Int32.min_int, Int32.to_int Int32.max_int
   else 0, 0
 
 module Decoder = struct

--- a/src/protobuf.ml
+++ b/src/protobuf.ml
@@ -223,6 +223,10 @@ module Encoder = struct
   let creates s =
     let t = Buffer.create (Bytes.length s) in
     let _ = Buffer.add_bytes t s in t;;
+
+  let of_bytes e s =
+    Buffer.reset e;
+    Buffer.add_bytes e s;;
     
   let to_string = Buffer.contents
 

--- a/src/protobuf.ml
+++ b/src/protobuf.ml
@@ -87,6 +87,8 @@ module Decoder = struct
       offset = 0;
       limit  = String.length source; }
 
+  let to_bytes t () = t.source    
+
   let decode_exn f source =
     f (of_bytes source)
 
@@ -218,6 +220,10 @@ module Encoder = struct
   let create () =
     Buffer.create 16
 
+  let creates s =
+    let t = Buffer.create (Bytes.length s) in
+    let _ = Buffer.add_bytes t s in t;;
+    
   let to_string = Buffer.contents
 
   let to_bytes = Buffer.to_bytes

--- a/src/protobuf.mli
+++ b/src/protobuf.mli
@@ -122,6 +122,7 @@ module Encoder : sig
       the use of protobuf-encoding for any type that must outwardly satisfy ability 
       to encode itself in protobuf form but for which we don't want to do so. *)
   val creates : bytes -> t
+  val of_bytes : t -> bytes -> unit
   (** [to_string e] converts the message assembled in [e] to a string. *)
   val to_string : t -> string
 

--- a/src/protobuf.mli
+++ b/src/protobuf.mli
@@ -32,6 +32,7 @@ module Decoder : sig
   (** [of_string s] creates a decoder positioned at start of string [s]. *)
   val of_string : string -> t
 
+  val to_bytes : t -> unit -> bytes
   (** [at_end d] returns [true] if [d] has exhausted its input, and [false]
       otherwise. *)
   val at_end    : t -> bool
@@ -116,7 +117,11 @@ module Encoder : sig
 
   (** [create ()] creates a new encoder. *)
   val create    : unit -> t
-
+  (** [create bytes] creates a new encoder with the arbitrary contents of bytes. 
+      Use with caution. Allows client code to bypass 
+      the use of protobuf-encoding for any type that must outwardly satisfy ability 
+      to encode itself in protobuf form but for which we don't want to do so. *)
+  val creates : bytes -> t
   (** [to_string e] converts the message assembled in [e] to a string. *)
   val to_string : t -> string
 

--- a/src_test/test_syntax.ml
+++ b/src_test/test_syntax.ml
@@ -1,8 +1,8 @@
 open OUnit2
 type uint32 = Uint32.t
 type uint64 = Uint64.t
-let hex_of_string s =
-  Core.Std.String.concat_map s ~f:(fun c -> Core.Std.sprintf "%02X" (Core.Std.Char.to_int c));;    
+(*let hex_of_string s =
+  Core.Std.String.concat_map s ~f:(fun c -> Core.Std.sprintf "%02X" (Core.Std.Char.to_int c));;    *)
 let assert_roundtrip printer encoder decoder str value =
   (* encode *)
   let e = Protobuf.Encoder.create () in

--- a/src_test/test_syntax.ml
+++ b/src_test/test_syntax.ml
@@ -1,19 +1,14 @@
 open OUnit2
 type uint32 = Uint32.t
 type uint64 = Uint64.t
-(*let hex_of_string s =
-  Core.Std.String.concat_map s ~f:(fun c -> Core.Std.sprintf "%02X" (Core.Std.Char.to_int c));;    *)
+
 let assert_roundtrip printer encoder decoder str value =
   (* encode *)
   let e = Protobuf.Encoder.create () in
   encoder value e;
-  (*let h = hex_of_string (Protobuf.Encoder.to_string e) in
-  print_string ("\nEncoder:" ^ h ^ " | " ^ ((Printf.sprintf "%S") str) ^ "\n");*)
+  assert_equal ~printer:(Printf.sprintf "%S") str (Protobuf.Encoder.to_string e);
   (* decode *)
   let d = Protobuf.Decoder.of_string str in
-  (*let h2 = hex_of_string (printer value) in
-  print_string ("\nDecoder:" ^ h2 ^ " | " ^ (printer value) ^ "\n");*)
-  assert_equal ~printer:(Printf.sprintf "%S") str (Protobuf.Encoder.to_string e);
   assert_equal ~printer value (decoder d)
 
 type b = bool [@@deriving protobuf]
@@ -302,11 +297,10 @@ let test_variant_optrep ctxt =
                    "\x08\x01" (V5A None);
   assert_roundtrip printer v5_to_protobuf v5_from_protobuf
 		   "\x08\x02\x1a\x02\x34\x32\x1a\x02\x34\x33" (V5B ["42"; "43"]);
-  (*"\x08\x02\x1a\x0242\x1a\x0243" (V5B ["42"; "43"]);*)
   assert_roundtrip printer v5_to_protobuf v5_from_protobuf
                    "\x08\x02" (V5B []);
   assert_roundtrip printer v5_to_protobuf v5_from_protobuf
-                   (*"\x08\x03\x20\x2a\x20\x2b"*) "\x08\x04\x28\x2A\x28\x2B" (V5C [|42; 43|]);
+                   "\x08\x04\x28\x2A\x28\x2B" (V5C [|42; 43|]);
   assert_roundtrip printer v5_to_protobuf v5_from_protobuf
                    "\x08\x04" (V5C [||])
    


### PR DESCRIPTION
I think lines 10 and 12 in protobuf.ml are typos as to the intended use of max and min values? I believe these were causing spurious overflow errors. I also updated the unit tests to pass in other ways; I think I did so correctly, including updating some of the hex strings. I am only here because I had problems while working on a different code base that depends on ppx_deriving_protobuf and after a recent update via opam I eventually figured out the problem lay here.
-Paul