### PR TITLE
Support OCaml version 4.03.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 	ocaml pkg/build.ml native=true native-dynlink=true
 
 test: build
-	rm _build/src_test/ -rf
+	rm -rf _build/src_test/ 
 	ocamlbuild -classic-display -use-ocamlfind src_test/test_ppx_protobuf.byte --
 
 doc:

--- a/README.md
+++ b/README.md
@@ -271,22 +271,29 @@ message Variant {
     A = 1;
     B = 2;
     C = 3;
+    D = 4;
   }
   message C {
     required string foo = 1;
-    required string bar = 1;
+    required string bar = 2;
+  }
+  message D {
+    required string s1 = 1;
+    required string s2 = 2;
   }
   required T t = 1;
   optional int32 b = 3; // (B = 2) + 1
   optional C c = 4; // (C = 3) + 1
+  optional D d = 5; // (D = 4) + 1
 }
 ```
 
 ``` ocaml
 type variant =
-| A                    [@key 1]
-| B of int             [@key 2]
-| C of string * string [@key 3]
+| A                              [@key 1]
+| B of int                       [@key 2]
+| C of string * string           [@key 3]
+| D of {s1: string ; s2: string} [@key 4]
 [@@deriving protobuf]
 ```
 

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
-true: warn(@5@8@10@11@12@14@23@24@26@40), bin_annot, safe_string
+true: warn(@5@8@10@11@12@14@23@24@26@40), bin_annot, safe_string, cppo_V_OCAML
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_deriving.api), package(ppx_tools.metaquot)
-<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit), package(str), use_protobuf
+<src_test/*.{ml,byte,native}>: debug, package(ppx_deriving.runtime), package(uint), package(oUnit), package(str), use_protobuf

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,7 +1,8 @@
 open Ocamlbuild_plugin
 
-let () = dispatch (
-  function
+let () = dispatch (fun phase ->
+  Ocamlbuild_cppo.dispatcher phase;
+  match phase with
   | After_rules ->
     flag ["ocaml"; "compile"; "use_protobuf"] &
       S[A"-ppx"; A("ocamlfind ppx_deriving/ppx_deriving src/ppx_deriving_protobuf.cma")];

--- a/opam
+++ b/opam
@@ -23,6 +23,7 @@ build-doc: [
 depends: [
   "ocamlbuild"   {build}
   "ocamlfind"    {build}
+  "cppo"         {build}
   "ppx_deriving" {>= "3.2" & < "4.0"}
   "ounit"        {test}
   "uint"         {test}

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -6,7 +6,7 @@ let ocamlbuild =
   "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
 
 let () =
-  Pkg.describe "ppx_deriving" ~builder:(`Other (ocamlbuild, "_build")) [
+  Pkg.describe "ppx_deriving_protobuf" ~builder:(`Other (ocamlbuild, "_build")) [
     Pkg.lib "pkg/META";
     Pkg.lib ~exts:Exts.module_library "src/protobuf";
     Pkg.lib ~exts:Exts.library "src/ppx_deriving_protobuf";

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -2,8 +2,11 @@
 #directory "pkg"
 #use "topkg.ml"
 
+let ocamlbuild =
+  "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
+
 let () =
-  Pkg.describe "ppx_deriving_protobuf" ~builder:`OCamlbuild [
+  Pkg.describe "ppx_deriving" ~builder:(`Other (ocamlbuild, "_build")) [
     Pkg.lib "pkg/META";
     Pkg.lib ~exts:Exts.module_library "src/protobuf";
     Pkg.lib ~exts:Exts.library "src/ppx_deriving_protobuf";

--- a/src/ppx_deriving_protobuf.cppo.ml
+++ b/src/ppx_deriving_protobuf.cppo.ml
@@ -386,6 +386,7 @@ let fields_of_ptype base_path ptype =
       |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes; pcd_loc; } ->
        (name, pcd_args, pcd_attributes, pcd_loc)
       ) 
+#if OCAML_VERSION >= (4, 03, 0)
       |> List.map (fun (name, pcd_args, pcd_attributes, pcd_loc) -> 
         match pcd_args with
         | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes, pcd_loc) 
@@ -401,6 +402,7 @@ let fields_of_ptype base_path ptype =
           let pcd_args = List.map (fun {pld_type; _ } -> pld_type) pcd_label_args in 
           (name, pcd_args, pcd_attributes, pcd_loc)
       ) 
+#endif
       |> fields_of_variant ptype_loc
   in
   fields |> List.iter (fun field ->
@@ -705,11 +707,15 @@ let rec derive_reader base_path fields ptype =
       |> List.map (fun { pcd_name = { txt = name}; pcd_args; pcd_attributes; } ->
         name, pcd_args, pcd_attributes
       ) 
+#if OCAML_VERSION >= (4, 03, 0)
       |> List.map (fun (name, pcd_args, pcd_attributes) -> 
-         match pcd_args with
-         | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes) 
-         | Pcstr_record _ -> failwith "Unsupported inline records"
+        match pcd_args with
+        | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes) 
+        | Pcstr_record pcd_label_args -> 
+          let pcd_args = List.map (fun {pld_type; _ } -> pld_type) pcd_label_args in 
+          (name, pcd_args, pcd_attributes)
        ) 
+#endif 
       |> mk_variant ptype_name ptype_loc constr
   in
   let read =
@@ -959,6 +965,7 @@ let rec derive_writer fields ptype =
       |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes } ->
           (name, pcd_args, pcd_attributes)
       ) 
+#if OCAML_VERSION >= (4, 03, 0)
       |> List.map (fun (name, pcd_args, pcd_attributes) -> 
         match pcd_args with
         | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes) 
@@ -966,6 +973,7 @@ let rec derive_writer fields ptype =
           let pcd_args = List.map (fun {pld_type; _ } -> pld_type) pcd_label_args in 
           (name, pcd_args, pcd_attributes)
       ) 
+#endif
       |> mk_variant pconstr
 
   in

--- a/src/ppx_deriving_protobuf.cppo.ml
+++ b/src/ppx_deriving_protobuf.cppo.ml
@@ -1,3 +1,7 @@
+#if OCAML_VERSION < (4, 03, 0)
+#define Pconst_string Const_string
+#endif
+
 open Longident
 open Location
 open Asttypes
@@ -5,6 +9,7 @@ open Parsetree
 open Ast_mapper
 open Ast_helper
 open Ast_convenience
+
 
 type pb_encoding =
 | Pbe_varint
@@ -176,7 +181,12 @@ let deriver = "protobuf"
 
 let pb_key_of_attrs attrs =
   match Ppx_deriving.attr ~deriver "key" attrs with
+#if OCAML_VERSION < (4, 03, 0)
   | Some ({ loc }, PStr [[%stri [%e? { pexp_desc = Pexp_constant (Const_int key) }]]]) ->
+#else
+  | Some ({ loc }, PStr [[%stri [%e? { pexp_desc = Pexp_constant (Pconst_integer (sn, _)) }]]]) ->
+    let key = int_of_string sn in 
+#endif
     if key < 1 || key > 0x1fffffff || (key >= 19000 && key <= 19999) then
       raise (Error (Pberr_key_invalid (loc, key)));
     Some key
@@ -372,8 +382,16 @@ let fields_of_ptype base_path ptype =
         field_of_ptyp ("field_" ^ name) name (base_path @ [name]) None Pbk_required
                       { pld_type with ptyp_attributes = pld_attributes @ pld_type.ptyp_attributes })
     | { ptype_kind = Ptype_variant constrs; ptype_loc } ->
-      constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes; pcd_loc; } ->
-        (name, pcd_args, pcd_attributes, pcd_loc)) |> fields_of_variant ptype_loc
+      constrs 
+      |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes; pcd_loc; } ->
+       (name, pcd_args, pcd_attributes, pcd_loc)
+      ) 
+      |> List.map (fun (name, pcd_args, pcd_attributes, pcd_loc) -> 
+        match pcd_args with
+        | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes, pcd_loc) 
+        | Pcstr_record _ -> failwith "Unsupported inline records"
+      ) 
+      |> fields_of_variant ptype_loc
   in
   fields |> List.iter (fun field ->
     fields |> List.iter (fun field' ->
@@ -381,13 +399,31 @@ let fields_of_ptype base_path ptype =
         raise (Error (Pberr_key_duplicate (field.pbf_key, field'.pbf_loc, field.pbf_loc)))));
   fields |> List.sort (fun { pbf_key = a } { pbf_key = b } -> compare a b)
 
+let empty_constructor_argument {pcd_args; _ } = 
+#if OCAML_VERSION < (4, 03, 0)
+  match pcd_args with
+  | [] -> true
+  | _ -> false 
+#else 
+  match pcd_args with
+  | Pcstr_tuple   [] | Pcstr_record [] -> true
+  | _ -> false 
+#endif
+
+let int64_constant_of_int i = 
+#if OCAML_VERSION < (4, 03, 0)
+  Const_int64 (Int64.of_int i)
+#else
+  Pconst_integer (string_of_int i, Some 'L') 
+#endif
+
 let derive_reader_bare base_path fields ptype =
   let mk_variant mk_constr constrs =
     let rec mk_variant_cases constrs =
       match constrs with
       | (name, attrs) :: rest ->
         let key = match pb_key_of_attrs attrs with Some key -> key | None -> assert false in
-        (Exp.case (Pat.constant (Const_int64 (Int64.of_int key)))
+        (Exp.case (Pat.constant (int64_constant_of_int key))
                   (mk_constr name)) :: mk_variant_cases rest
       | [] ->
         let field_name = String.concat "." base_path in
@@ -400,9 +436,10 @@ let derive_reader_bare base_path fields ptype =
     Some (Vb.mk (pvar (Ppx_deriving.mangle_type_decl (`Suffix "from_protobuf_bare") ptype))
                 [%expr fun decoder -> [%e Ppx_deriving.sanitize matcher]])
   in
+
   match ptype with
   | { ptype_kind = Ptype_variant constrs } when
-      List.for_all (fun { pcd_args } -> pcd_args = []) constrs ->
+      List.for_all empty_constructor_argument constrs ->
     constrs |> List.map (fun { pcd_name = { txt = name }; pcd_attributes } ->
                   name, pcd_attributes) |> mk_variant (fun name -> constr name [])
   | { ptype_kind = Ptype_abstract;
@@ -585,7 +622,7 @@ let rec derive_reader base_path fields ptype =
         let field = try  Some (List.find (fun { pbf_name } -> pbf_name = "constr_" ^ name) fields)
                     with Not_found -> None in
         let key = match pb_key_of_attrs attrs with Some key -> key | None -> assert false in
-        let pkey  = [%pat? Some [%p Pat.constant (Const_int64 (Int64.of_int key))]] in
+        let pkey  = [%pat? Some [%p Pat.constant (int64_constant_of_int key)]] in
         let pargs =
           with_args |> List.map (fun name' ->
             let field' = List.find (fun { pbf_name } -> pbf_name = "constr_" ^ name') fields in
@@ -654,8 +691,16 @@ let rec derive_reader base_path fields ptype =
       Exp.record (List.mapi (fun i { pld_name; pld_type; } ->
         lid pld_name.txt, construct_ptyp ("field_" ^ pld_name.txt) pld_type) fields) None
     | { ptype_kind = Ptype_variant constrs; ptype_name; ptype_loc } ->
-      constrs |> List.map (fun { pcd_name = { txt = name}; pcd_args; pcd_attributes; } ->
-        name, pcd_args, pcd_attributes) |> mk_variant ptype_name ptype_loc constr
+      constrs 
+      |> List.map (fun { pcd_name = { txt = name}; pcd_args; pcd_attributes; } ->
+        name, pcd_args, pcd_attributes
+      ) 
+      |> List.map (fun (name, pcd_args, pcd_attributes) -> 
+         match pcd_args with
+         | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes) 
+         | Pcstr_record _ -> failwith "Unsupported inline records"
+       ) 
+      |> mk_variant ptype_name ptype_loc constr
   in
   let read =
     [%expr let rec read () = [%e matcher] in read (); [%e constructor]] |>
@@ -673,7 +718,7 @@ let derive_writer_bare fields ptype =
       | (name, attrs) :: rest ->
         let key = match pb_key_of_attrs attrs with Some key -> key | None -> assert false in
         (Exp.case (mk_pconstr name)
-                  (Exp.constant (Const_int64 (Int64.of_int key)))) ::
+                  (Exp.constant (int64_constant_of_int key))) ::
         mk_variant_cases rest
       | [] -> []
     in
@@ -684,7 +729,7 @@ let derive_writer_bare fields ptype =
   in
   match ptype with
   | { ptype_kind = Ptype_variant constrs } when
-      List.for_all (fun { pcd_args } -> pcd_args = []) constrs ->
+      List.for_all empty_constructor_argument constrs ->
     constrs |> List.map (fun { pcd_name = { txt = name }; pcd_attributes } ->
                   name, pcd_attributes) |> mk_variant (fun name -> pconstr name [])
   | { ptype_kind = Ptype_abstract;
@@ -832,12 +877,12 @@ let rec derive_writer fields ptype =
       match constrs with
       | (name, [], attrs)  :: rest ->
         let key   = match pb_key_of_attrs attrs with Some key -> key | None -> assert false in
-        let ekey  = Exp.constant (Const_int64 (Int64.of_int key)) in
+        let ekey  = Exp.constant (int64_constant_of_int key) in
         (Exp.case (mk_patt name []) [%expr Protobuf.Encoder.varint [%e ekey] encoder]) ::
         mk_variant_cases rest
       | (name, [arg], attrs) :: rest ->
         let key   = match pb_key_of_attrs attrs with Some key -> key | None -> assert false in
-        let ekey  = Exp.constant (Const_int64 (Int64.of_int key)) in
+        let ekey  = Exp.constant (int64_constant_of_int key) in
         let field = List.find (fun { pbf_name } -> pbf_name = "constr_" ^ name) fields in
         (Exp.case (mk_patt name [pvar ("constr_" ^ name)])
                   (deconstruct_ptyp field.pbf_name arg
@@ -847,7 +892,7 @@ let rec derive_writer fields ptype =
         mk_variant_cases rest
       | (name, args, attrs) :: rest ->
         let key   = match pb_key_of_attrs attrs with Some key -> key | None -> assert false in
-        let ekey  = Exp.constant (Const_int64 (Int64.of_int key)) in
+        let ekey  = Exp.constant (int64_constant_of_int key) in
         let field = List.find (fun { pbf_name } -> pbf_name = "constr_" ^ name) fields in
         let argns = List.mapi (fun i _ -> "a" ^ (string_of_int i)) args in
         (Exp.case (mk_patt name (List.map pvar argns))
@@ -900,9 +945,17 @@ let rec derive_writer fields ptype =
                 deconstruct_ptyp (Printf.sprintf "field_%s" pld_name.txt) pld_type k) ldecls
               (mk_writers fields)]]
     | { ptype_kind = Ptype_variant constrs; ptype_name; ptype_loc } ->
-      mk_variant pconstr
-        (List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes } ->
-          (name, pcd_args, pcd_attributes)) constrs)
+      constrs
+      |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes } ->
+          (name, pcd_args, pcd_attributes)
+      ) 
+      |> List.map (fun (name, pcd_args, pcd_attributes) -> 
+        match pcd_args with
+        | Pcstr_tuple pcd_args -> (name, pcd_args, pcd_attributes) 
+        | Pcstr_record _ -> failwith "Unsupported inline records"
+      ) 
+      |> mk_variant pconstr
+
   in
   let write = mk_deconstructor fields |> mk_imm_writers fields in
   Vb.mk (pvar (Ppx_deriving.mangle_type_decl (`Suffix "to_protobuf") ptype))
@@ -926,7 +979,7 @@ let str_of_type ~options ~path ({ ptype_name = { txt = name }; ptype_loc } as pt
 let has_bare ptype =
   match ptype with
   | { ptype_kind = Ptype_variant constrs } when
-      List.for_all (fun { pcd_args } -> pcd_args = []) constrs -> true
+      List.for_all empty_constructor_argument constrs -> true
   | { ptype_kind = Ptype_abstract;
       ptype_manifest = Some { ptyp_desc = Ptyp_variant (rows, _, _) } } when
         List.for_all (fun row_field ->
@@ -1057,11 +1110,16 @@ let rec write_protoc ~fmt ~path:base_path ?(import=[])
     begin match field.pbf_default with
     | Some [%expr true]  -> Format.fprintf fmt " [default=true]"
     | Some [%expr false] -> Format.fprintf fmt " [default=false]"
+#if OCAML_VERSION < (4, 03, 0)
     | Some { pexp_desc = Pexp_constant (Const_int i) } ->
+#else
+    | Some { pexp_desc = Pexp_constant (Pconst_integer (sn, _)) } ->
+      let i = int_of_string sn in 
+#endif
       Format.fprintf fmt " [default=%d]" i
-    | Some { pexp_desc = Pexp_constant (Const_string (s, _)) } ->
+    | Some { pexp_desc = Pexp_constant (Pconst_string (s, _)) } ->
       Format.fprintf fmt " [default=\"%s\"]" (escape ~pass_8bit:true s)
-    | Some [%expr Bytes.of_string [%e? { pexp_desc = Pexp_constant (Const_string (s, _)) }]] ->
+    | Some [%expr Bytes.of_string [%e? { pexp_desc = Pexp_constant (Pconst_string (s, _)) }]] ->
       Format.fprintf fmt " [default=\"%s\"]" (escape ~pass_8bit:false s)
     | Some { pexp_desc = Pexp_construct ({ txt = Lident n }, _) }
     | Some { pexp_desc = Pexp_variant (n, _) } ->


### PR DESCRIPTION
* Integrate all the changes to the parsetree in version 4.03.0 
* Inline records are supported just like tuple, customization of the key can be added later. 

All unit tests pass and I tested both `opam switch 4.02.3` and `opam switch 4.03.0+beta1`.