### PR TITLE
Add support for OCaml 4.03.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 	ocaml pkg/build.ml native=true native-dynlink=true
 
 test: build
-	rm _build/src_test/ -rf
+	rm -rf _build/src_test/ 
 	ocamlbuild -classic-display -use-ocamlfind src_test/test_ppx_protobuf.byte --
 
 doc:

--- a/README.md
+++ b/README.md
@@ -271,22 +271,29 @@ message Variant {
     A = 1;
     B = 2;
     C = 3;
+    D = 4;
   }
   message C {
     required string foo = 1;
-    required string bar = 1;
+    required string bar = 2;
+  }
+  message D {
+    required string s1 = 1;
+    required string s2 = 2;
   }
   required T t = 1;
   optional int32 b = 3; // (B = 2) + 1
   optional C c = 4; // (C = 3) + 1
+  optional D d = 5; // (D = 4) + 1
 }
 ```
 
 ``` ocaml
 type variant =
-| A                    [@key 1]
-| B of int             [@key 2]
-| C of string * string [@key 3]
+| A                              [@key 1]
+| B of int                       [@key 2]
+| C of string * string           [@key 3]
+| D of {s1: string ; s2: string} [@key 4]
 [@@deriving protobuf]
 ```
 

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
-true: warn(@5@8@10@11@12@14@23@24@26@40), bin_annot, safe_string
+true: warn(@5@8@10@11@12@14@23@24@26@40), bin_annot, safe_string, cppo_V_OCAML
 
 "src": include
 <src/*.{ml,mli,byte,native}>: package(ppx_deriving.api), package(ppx_tools.metaquot)
-<src_test/*.{ml,byte,native}>: debug, package(uint), package(oUnit), package(str), use_protobuf
+<src_test/*.{ml,byte,native}>: debug, package(ppx_deriving.runtime), package(uint), package(oUnit), package(str), use_protobuf

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,7 +1,8 @@
 open Ocamlbuild_plugin
 
-let () = dispatch (
-  function
+let () = dispatch (fun phase ->
+  Ocamlbuild_cppo.dispatcher phase;
+  match phase with
   | After_rules ->
     flag ["ocaml"; "compile"; "use_protobuf"] &
       S[A"-ppx"; A("ocamlfind ppx_deriving/ppx_deriving src/ppx_deriving_protobuf.cma")];

--- a/opam
+++ b/opam
@@ -23,6 +23,7 @@ build-doc: [
 depends: [
   "ocamlbuild"   {build}
   "ocamlfind"    {build}
+  "cppo"         {build}
   "ppx_deriving" {>= "3.2" & < "4.0"}
   "ounit"        {test}
   "uint"         {test}

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -2,8 +2,11 @@
 #directory "pkg"
 #use "topkg.ml"
 
+let ocamlbuild =
+  "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
+
 let () =
-  Pkg.describe "ppx_deriving_protobuf" ~builder:`OCamlbuild [
+  Pkg.describe "ppx_deriving_protobuf" ~builder:(`Other (ocamlbuild, "_build")) [
     Pkg.lib "pkg/META";
     Pkg.lib ~exts:Exts.module_library "src/protobuf";
     Pkg.lib ~exts:Exts.library "src/ppx_deriving_protobuf";


### PR DESCRIPTION
* Integrate all the changes to the parsetree in version 4.03.0 
* Inline records are supported just like tuple, customization of the key can be added later. 

All unit tests pass and I tested both `opam switch 4.02.3` and `opam switch 4.03.0+beta1`.