### PR TITLE
Add support for NPM package manager

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+_tags
+pkg
+doc
+src_test
+opam
+desc
+myocamlbuild.ml
+.travis.yml
+Makefile

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,0 +1,12 @@
+{
+  "name": "bs-ppx_deriving_protobuf",
+  "sources": {
+    "dir": "src",
+    "public": ["Protobuf"],
+    "files": [
+      "protobuf.mli",
+      "protobuf.ml"
+    ]
+  },
+  "generate-merlin": false
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "bs-ppx_deriving_protobuf",
+  "version": "2.5.0",
+  "description": "A Protocol Buffers codec generator for OCaml >=4.02",
+  "keywords": ["protobuf", "serialization", "syntax", "bucklescript"],
+  "homepage": "https://github.com/whitequark/ppx_deriving_protobuf",
+  "bugs": "https://github.com/whitequark/ppx_deriving_protobuf/issues",
+  "license": "MIT",
+  "author": " whitequark <whitequark@whitequark.org>",
+  "main": "lib/src/protobuf.js",
+  "repository" : { 
+    "type": "git", 
+    "url": "https://github.com/whitequark/ppx_deriving_protobuf"
+  },
+  "devDependencies": {
+    "bs-platform": "^1.5.0"
+  },
+
+  "peerDependencies": {
+    "bs-platform": "^1.5.0"
+  }
+}


### PR DESCRIPTION
This PR adds the necessary configuration files for publishing ppx_deriving_protobuf runtime library to the NPM package manager using BuckleScript for transpiling to JS. 

The npm package is available at https://www.npmjs.com/package/bs-ppx_deriving_protobuf. The bs-<package-name> is intentional so that:
* it avoids conflict with ongoing effort to mirror opam package in npm (no JS involved) 
* it clearly indicates this package works with BuckleScript and require BuckleScript as dependency to work. 