### PR TITLE
Fix varint decoding

### DIFF
--- a/src/protobuf.ml
+++ b/src/protobuf.ml
@@ -108,7 +108,7 @@ module Decoder = struct
       let b = byte d in
       if b land 0x80 <> 0 then
         Int64.(logor (shift_left (logand (of_int b) 0x7fL) s) (read (s + 7)))
-      else if s < 56 || (b land 0x7f) <= 1 then
+      else if s < 63 || (b land 0x7f) <= 1 then
         Int64.(shift_left (of_int b) s)
       else
         raise (Failure Overlong_varint)

--- a/src_test/test_wire.ml
+++ b/src_test/test_wire.ml
@@ -39,6 +39,8 @@ let test_decoder ctxt =
   assert_equal ~printer:Int64.to_string (-2L) (Decoder.zigzag d);
   let d = Decoder.of_string "\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01" in
   assert_equal ~printer:Int64.to_string 0xffffffffffffffffL (Decoder.varint d);
+  let d = Decoder.of_string "\x80\x80\x80\x80\x80\x80\x80\x80\x03" in
+  assert_equal ~printer:Int64.to_string Int64.(shift_left 3L 56) (Decoder.varint d);
   let d = Decoder.of_string "\xff\xff\xff\xff\xff\xff\xff\xff\xff\x02" in
   assert_raises (Decoder.Failure Decoder.Overlong_varint)
                 (fun () -> Decoder.varint d);


### PR DESCRIPTION
The current code fails to decode integers such as (3 << 56).   